### PR TITLE
Added DependencyEdge::isDevDependency()

### DIFF
--- a/src/JMS/Composer/DependencyAnalyzer.php
+++ b/src/JMS/Composer/DependencyAnalyzer.php
@@ -122,7 +122,7 @@ class DependencyAnalyzer
 
             if (isset($packageData['require-dev'])) {
                 foreach ($packageData['require-dev'] as $name => $version) {
-                    $this->connect($graph, $packageData['name'], $name, $version, true);
+                    $this->connect($graph, $packageData['name'], $name, $version);
                 }
             }
         }
@@ -143,11 +143,11 @@ class DependencyAnalyzer
         return $graph;
     }
 
-    private function connect(DependencyGraph $graph, $sourceName, $destName, $version, $isdev = false)
+    private function connect(DependencyGraph $graph, $sourceName, $destName, $version)
     {
         // If the dest package is available, just connect it.
         if ($graph->hasPackage($destName)) {
-            $graph->connect($sourceName, $destName, $version, $isdev);
+            $graph->connect($sourceName, $destName, $version);
 
             return;
         }
@@ -156,7 +156,7 @@ class DependencyAnalyzer
         // some aggregate package that replaces our dest package, and connect to
         // this package.
         if (null !== $aggregatePackage = $graph->getAggregatePackageContaining($destName)) {
-            $graph->connect($sourceName, $aggregatePackage->getName(), $version, $isdev);
+            $graph->connect($sourceName, $aggregatePackage->getName(), $version);
 
             return;
         }
@@ -164,7 +164,7 @@ class DependencyAnalyzer
         // If we reach this, we have stumbled upon a package that is only available
         // if the source package is installed with dev dependencies. We still add
         // the connection, but we will not have any data about the dest package.
-        $graph->connect($sourceName, $destName, $version, $isdev);
+        $graph->connect($sourceName, $destName, $version);
     }
 
     private function processLockedData(DependencyGraph $graph, array $lockedPackageData)

--- a/src/JMS/Composer/Graph/DependencyEdge.php
+++ b/src/JMS/Composer/Graph/DependencyEdge.php
@@ -32,23 +32,17 @@ class DependencyEdge
      * @var string
      */
     private $versionConstraint;
-    /**
-     * @var bool
-     */
-    private $isDev;
 
     /**
      * @param PackageNode $sourcePackage
      * @param PackageNode $destPackage
      * @param string      $versionConstraint
-     * @param bool        $isDev
      */
-    public function __construct(PackageNode $sourcePackage, PackageNode $destPackage, $versionConstraint, $isDev)
+    public function __construct(PackageNode $sourcePackage, PackageNode $destPackage, $versionConstraint)
     {
         $this->sourcePackage = $sourcePackage;
         $this->destPackage = $destPackage;
         $this->versionConstraint = $versionConstraint;
-        $this->isDev = $isDev;
     }
 
     /**
@@ -78,9 +72,10 @@ class DependencyEdge
     /**
      * @return bool
      */
-    public function getIsDevDependecy()
+    public function isDevDependency()
     {
-        return $this->isDev;
-    }
+        $data = $this->sourcePackage->getData();
 
+        return isset($data['require-dev'][$this->destPackage->getName()]);
+    }
 }

--- a/src/JMS/Composer/Graph/DependencyGraph.php
+++ b/src/JMS/Composer/Graph/DependencyGraph.php
@@ -36,6 +36,9 @@ class DependencyGraph
      */
     private $rootPackage;
 
+    /**
+     * @param PackageNode|null $rootPackage
+     */
     public function __construct(PackageNode $rootPackage = null)
     {
         if (null !== $rootPackage) {
@@ -45,31 +48,59 @@ class DependencyGraph
         $this->rootPackage = $rootPackage ?: $this->getOrCreate('__root');
     }
 
+    /**
+     * @return PackageNode
+     */
     public function getRootPackage()
     {
         return $this->rootPackage;
     }
 
+    /**
+     * @param PackageNode $node
+     *
+     * @return bool
+     */
     public function isRootPackage(PackageNode $node)
     {
         return $node === $this->rootPackage;
     }
 
+    /**
+     * @return PackageNode[]
+     */
     public function getPackages()
     {
         return $this->packages;
     }
 
+    /**
+     * @param string $name
+     *
+     * @return PackageNode|null
+     */
     public function getPackage($name)
     {
         return isset($this->packages[$name]) ? $this->packages[$name] : null;
     }
 
+    /**
+     * @param string $name
+     *
+     * @return bool
+     */
     public function hasPackage($name)
     {
         return isset($this->packages[$name]);
     }
 
+    /**
+     * @param string $name
+     * @param array  $data
+     *
+     * @throws \InvalidArgumentException
+     * @return PackageNode
+     */
     public function createPackage($name, array $data = array())
     {
         if (isset($this->packages[$name])) {
@@ -79,7 +110,12 @@ class DependencyGraph
         return $this->packages[$name] = new PackageNode($name, $data);
     }
 
-    public function connect($packageA, $packageB, $versionConstraint, $isDev)
+    /**
+     * @param string $packageA
+     * @param string $packageB
+     * @param string $versionConstraint
+     */
+    public function connect($packageA, $packageB, $versionConstraint)
     {
         $nodeA = $this->getOrCreate($packageA);
         $nodeB = $this->getOrCreate($packageB);
@@ -91,7 +127,7 @@ class DependencyGraph
             }
         }
 
-        $edge = new DependencyEdge($nodeA, $nodeB, $versionConstraint, $isDev);
+        $edge = new DependencyEdge($nodeA, $nodeB, $versionConstraint);
         $nodeA->addOutEdge($edge);
         $nodeB->addInEdge($edge);
     }
@@ -114,6 +150,11 @@ class DependencyGraph
         return null;
     }
 
+    /**
+     * @param string $package
+     *
+     * @return PackageNode
+     */
     private function getOrCreate($package)
     {
         if (isset($this->packages[$package])) {


### PR DESCRIPTION
There was no way to see if a package dependency was a require-dev package or not.
