### PR TITLE
Make sure tests work with PHP 5.3

### DIFF
--- a/tests/JMS/Tests/Composer/Graph/DependencyGraphTest.php
+++ b/tests/JMS/Tests/Composer/Graph/DependencyGraphTest.php
@@ -9,7 +9,9 @@ class DependencyGraphTest extends \PHPUnit_Framework_TestCase
     public function testImplicitCreationOfRootPackage()
     {
         $graph = new DependencyGraph();
-        $this->assertCount(1, $graph->getPackages());
-        $this->assertTrue($graph->isRootPackage($graph->getPackages()['__root']));
+        $packages = $graph->getPackages();
+        
+        $this->assertCount(1, $packages);
+        $this->assertTrue($graph->isRootPackage($packages['__root']));
     }
 }


### PR DESCRIPTION
This **very** simple patch fixes unit tests compatibility with PHP 5.3 (which should be supported according to your `composer.json`)
