### PR TITLE
Use case-insensitive search when matching package names

### DIFF
--- a/src/JMS/Composer/Graph/DependencyEdge.php
+++ b/src/JMS/Composer/Graph/DependencyEdge.php
@@ -74,8 +74,6 @@ class DependencyEdge
      */
     public function isDevDependency()
     {
-        $data = $this->sourcePackage->getData();
-
-        return isset($data['require-dev'][$this->destPackage->getName()]);
+        return $this->sourcePackage->hasDataKey('require-dev', $this->destPackage->getName());
     }
 }

--- a/src/JMS/Composer/Graph/DependencyEdge.php
+++ b/src/JMS/Composer/Graph/DependencyEdge.php
@@ -74,6 +74,6 @@ class DependencyEdge
      */
     public function isDevDependency()
     {
-        return $this->sourcePackage->hasDataKey('require-dev', $this->destPackage->getName());
+        return $this->sourcePackage->hasDataPackageKey('require-dev', $this->destPackage->getName());
     }
 }

--- a/src/JMS/Composer/Graph/DependencyGraph.php
+++ b/src/JMS/Composer/Graph/DependencyGraph.php
@@ -42,7 +42,7 @@ class DependencyGraph
     public function __construct(PackageNode $rootPackage = null)
     {
         if (null !== $rootPackage) {
-            $this->packages[$rootPackage->getName()] = $rootPackage;
+            $this->packages[strtolower($rootPackage->getName())] = $rootPackage;
         }
 
         $this->rootPackage = $rootPackage ?: $this->getOrCreate('__root');
@@ -72,7 +72,7 @@ class DependencyGraph
      */
     public function isRootPackageName($name)
     {
-        return $this->rootPackage->getName() === $name;
+        return strtolower($this->rootPackage->getName()) === strtolower($name);
     }
 
     /**
@@ -90,7 +90,7 @@ class DependencyGraph
      */
     public function getPackage($name)
     {
-        return isset($this->packages[$name]) ? $this->packages[$name] : null;
+        return isset($this->packages[$name = strtolower($name)]) ? $this->packages[$name] : null;
     }
 
     /**
@@ -100,7 +100,7 @@ class DependencyGraph
      */
     public function hasPackage($name)
     {
-        return isset($this->packages[$name]);
+        return isset($this->packages[strtolower($name)]);
     }
 
     /**
@@ -112,11 +112,11 @@ class DependencyGraph
      */
     public function createPackage($name, array $data = array())
     {
-        if (isset($this->packages[$name])) {
+        if (isset($this->packages[strtolower($name)])) {
             throw new \InvalidArgumentException(sprintf('The package "%s" already exists.', $name));
         }
 
-        return $this->packages[$name] = new PackageNode($name, $data);
+        return $this->packages[strtolower($name)] = new PackageNode($name, $data);
     }
 
     /**
@@ -166,10 +166,10 @@ class DependencyGraph
      */
     private function getOrCreate($package)
     {
-        if (isset($this->packages[$package])) {
-            return $this->packages[$package];
+        if (isset($this->packages[strtolower($package)])) {
+            return $this->packages[strtolower($package)];
         }
 
-        return $this->packages[$package] = new PackageNode($package);
+        return $this->packages[strtolower($package)] = new PackageNode($package);
     }
 }

--- a/src/JMS/Composer/Graph/PackageNode.php
+++ b/src/JMS/Composer/Graph/PackageNode.php
@@ -218,11 +218,20 @@ class PackageNode
      */
     public function replaces($package)
     {
-        if ( ! isset($this->data['replace'])) {
-            return false;
-        }
+        return $this->hasDataKey('replace', $package);
+    }
 
-        return isset($this->data['replace'][$package]);
+    public function hasDataKey($key, $search)
+    {
+        if (isset($this->data[$key])) {
+            $search = strtolower($search);
+            foreach ($this->data[$key] as $k => $v) {
+                if (strtolower($k) === $search) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     /**

--- a/src/JMS/Composer/Graph/PackageNode.php
+++ b/src/JMS/Composer/Graph/PackageNode.php
@@ -218,15 +218,23 @@ class PackageNode
      */
     public function replaces($package)
     {
-        return $this->hasDataKey('replace', $package);
+        return $this->hasDataPackageKey('replace', $package);
     }
 
-    public function hasDataKey($key, $search)
+    /**
+     * Checks if this package has the given $packageName in its $data[$dataKey] hash.
+     *
+     * @param string $dataKey
+     * @param string $packageName
+     *
+     * @return bool
+     */
+    public function hasDataPackageKey($dataKey, $packageName)
     {
-        if (isset($this->data[$key])) {
-            $search = strtolower($search);
-            foreach ($this->data[$key] as $k => $v) {
-                if (strtolower($k) === $search) {
+        if (isset($this->data[$dataKey]) && is_array($this->data[$dataKey])) {
+            $packageName = strtolower($packageName);
+            foreach (array_keys($this->data[$dataKey]) as $k) {
+                if (strtolower($k) === $packageName) {
                     return true;
                 }
             }

--- a/tests/JMS/Tests/Composer/DependencyAnalyzerTest.php
+++ b/tests/JMS/Tests/Composer/DependencyAnalyzerTest.php
@@ -89,6 +89,7 @@ COMPOSER
         $tests[] = array('aggregate_package');
         $tests[] = array('unavailable_dev_package');
         $tests[] = array('dep_only_on_php_and_ext');
+        $tests[] = array('mixed_case');
 
         return $tests;
     }

--- a/tests/JMS/Tests/Composer/Fixture/mixed_case_composer.json
+++ b/tests/JMS/Tests/Composer/Fixture/mixed_case_composer.json
@@ -1,0 +1,24 @@
+{
+    "require": {
+        "Lower/Case": "dev-master"
+    },
+    "repositories": [
+        {
+            "type": "package",
+            "package": {
+                "name": "lower/case",
+                "version": "dev-master",
+                "require": {
+                    "mixed/case": "dev-master"
+                }
+            }
+        },
+        {
+            "type": "package",
+            "package": {
+                "name": "Mixed/Case",
+                "version": "dev-master"
+            }
+        }
+    ]
+}

--- a/tests/JMS/Tests/Composer/Fixture/mixed_case_composer.lock
+++ b/tests/JMS/Tests/Composer/Fixture/mixed_case_composer.lock
@@ -1,0 +1,15 @@
+{
+    "packages": [
+        {
+            "name": "lower/case",
+            "version": "dev-master",
+            "require": {
+                "mixed/case": "dev-master"
+            }
+        },
+        {
+            "name": "Mixed/Case",
+            "version": "dev-master"
+        }
+    ]
+}

--- a/tests/JMS/Tests/Composer/Fixture/mixed_case_graph.txt
+++ b/tests/JMS/Tests/Composer/Fixture/mixed_case_graph.txt
@@ -1,0 +1,15 @@
+__root (Root)
+=============
+Version: <null>
+-> lower/case
+
+
+Mixed/Case
+==========
+Version: dev-master
+
+
+lower/case
+==========
+Version: dev-master
+-> Mixed/Case


### PR DESCRIPTION
Composer matches all package names in a case insensitive manner, and so this PR makes sure we analyze the dependencies similarly.

After your recent changes to accommodate for mixed case of php extensions, this PR also applies a similar scheme to match all package names in case insensitive manner.

I'm not perfectly happy with the code quality of the outcome and can potentially see the need for a later refactoring, but I figured it's still a good idea to get some feedback on the progress. 

Refs clue/graph-composer#13
