### PR TITLE
Add strict isOnlyDevDependency() to check for dev dependencies

### DIFF
--- a/src/JMS/Composer/Graph/DependencyEdge.php
+++ b/src/JMS/Composer/Graph/DependencyEdge.php
@@ -77,9 +77,24 @@ class DependencyEdge
      * be created that is considered to be a dev dependency.
      *
      * @return bool
+     * @see self::isOnlyDevDependency()
      */
     public function isDevDependency()
     {
         return $this->sourcePackage->hasDataPackageKey('require-dev', $this->destPackage->getName());
+    }
+
+    /**
+     * Checks whether the source package lists the destination package only in require-dev
+     *
+     * If the source package lists the destination package in both "required-dev"
+     * and "require", this edge is not considered to be only a dev dependency.
+     *
+     * @return bool
+     * @see self::isDevDependency()
+     */
+    public function isOnlyDevDependency()
+    {
+        return ($this->isDevDependency() && !$this->sourcePackage->hasDataPackageKey('require', $this->destPackage->getName()));
     }
 }

--- a/tests/JMS/Tests/Composer/Graph/DependencyEdgeTest.php
+++ b/tests/JMS/Tests/Composer/Graph/DependencyEdgeTest.php
@@ -20,6 +20,7 @@ class DependencyEdgeTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('*', $edge->getVersionConstraint());
 
         $this->assertFalse($edge->isDevDependency());
+        $this->assertFalse($edge->isOnlyDevDependency());
     }
 
     public function testOnlyDev()
@@ -34,6 +35,7 @@ class DependencyEdgeTest extends \PHPUnit_Framework_TestCase
         $edge = new DependencyEdge($source, $destination, '*');
 
         $this->assertTrue($edge->isDevDependency());
+        $this->assertTrue($edge->isOnlyDevDependency());
     }
 
     public function testAlsoDev()
@@ -51,5 +53,6 @@ class DependencyEdgeTest extends \PHPUnit_Framework_TestCase
         $edge = new DependencyEdge($source, $destination, '*');
 
         $this->assertTrue($edge->isDevDependency());
+        $this->assertFalse($edge->isOnlyDevDependency());
     }
 }


### PR DESCRIPTION
The current `DependencyEdge::isDevDependency()` is a bit ambiguous with regards to mixed dev- and non-dev-dependencies: Source packages that list the dependency in both "require-dev" and "require" will only create a single edge that is considered to be a dev dependency.

This PR suggests to add a new `DependencyEdge::isOnlyDevDependency()` method to provide a stricter check for when a package is _only_ listed in "require-dev" instead.
